### PR TITLE
Replace all occurences of RFC with proposal

### DIFF
--- a/frameworks/engineering/backend.md
+++ b/frameworks/engineering/backend.md
@@ -121,12 +121,12 @@ Check out the original backend engineering framework [here](https://eng-progress
 ### Impact
 - Delivers large well-defined tasks and solves small scope not-well-defined problems
 
-- Contributes to writing RFCs (Co-authors with more experienced Engineer)
+- Contributes to writing proposals (Co-authors with more experienced Engineer)
 
 - Breaks down large problems into smaller iterative steps across multiple PRs
 
 ### Influence
-- Provides valuable input to RFCs from their team
+- Provides valuable input to proposals from their team
 
 - Proactively improves modules, services, systems and codebases they encounter, 'this doesn't make sense, I'm going to do something about it'
 
@@ -189,7 +189,7 @@ Check out the original backend engineering framework [here](https://eng-progress
 ### Impact
 - Solves ambiguous problems
 
-- Leads writing small/medium scope RFCs
+- Leads writing small/medium scope proposals
 
 - Thrown at fires and resolves / contributes heavily to resolving them
 
@@ -260,7 +260,7 @@ Check out the original backend engineering framework [here](https://eng-progress
 
     > **Examples**
     >
-    > Outbound and Inbound MasterCard clearing RFCs
+    > Outbound and Inbound MasterCard clearing proposals
 
 - Develops clear technical solutions from ambiguous requirements
 
@@ -287,7 +287,7 @@ Check out the original backend engineering framework [here](https://eng-progress
 
 - Leading large scale technical infrastructure projects (level 5 would originate or complete, probably)
 
-- Leads writing large scope RFCs
+- Leads writing large scope proposals
 
 - Breaks down large long-lasting projects into sensible discrete chunks that compound to achieve a large goal
 

--- a/frameworks/engineering/data.md
+++ b/frameworks/engineering/data.md
@@ -189,7 +189,7 @@ Check out the original data framework [here](https://eng-progression.monzo.com/f
 - Distinguishes well between impactful ML problems vs just “predicting something”
 
 ### Influence
-- Provides valuable input to RFCs from their team
+- Provides valuable input to proposals from their team
 
 - Proactively improves modules, services, systems and codebases they encounter, 'this doesn't make sense, I'm going to do something about it'
 

--- a/frameworks/engineering/mobile.md
+++ b/frameworks/engineering/mobile.md
@@ -113,11 +113,11 @@ Check out the original mobile engineering progression site [here](https://eng-pr
 ### Impact
 - Delivers large well-defined tasks and solves small scope not-well-defined problems
 
-- Contributes to writing RFCs (Co-authors with more experienced Engineer)
+- Contributes to writing proposals (Co-authors with more experienced Engineer)
 - Breaks down large problems into smaller iterative steps across multiple PRs
 
 ### Influence
-- Provides valuable input to RFCs from their team
+- Provides valuable input to proposals from their team
 
 - Proactively improves modules, services, systems and codebases they encounter, 'this doesn't make sense, I'm going to do something about it'
 - Contributes to scaling engineering hiring (e.g. leads calls, does onsite interviews)
@@ -163,13 +163,13 @@ Check out the original mobile engineering progression site [here](https://eng-pr
     > Modularisation
 - Debugs complex problems across a variety of subject areas
   - *Seeks out technical knowledge to compliment their own, researches and patches third party libraries where needed. Uses reasoning to debug and find the root cause of issues. Articulates problem and proposed solution to both technical and non technical peers.*
-- RFCs and architects complex app flows
+- Writes proposals and architects complex app flows
   - *Coordinates with backend developers around API specifications and requirements. Able to digest into discrete tasks and work with peers to solve problem in an efficient manner to avoid blockers.*
-- Sought out for reviewing complex changes or commenting on larger scale RFCs
+- Sought out for reviewing complex changes or commenting on larger scale proposals
 ### Impact
 - Solves ambiguous problems
 
-- Leads writing small/medium scope RFCs
+- Leads writing small/medium scope proposals
 - Thrown at fires and resolves / contributes heavily to resolving them
 - Makes pragmatic choices about taking on tech debt
 - Considers multiple different solutions for solving a problem
@@ -242,7 +242,7 @@ Check out the original mobile engineering progression site [here](https://eng-pr
 
 - Leading large scale technical infrastructure projects (level 5 would originate or complete, probably)
 
-- Leads writing large scope RFCs
+- Leads writing large scope proposals
 
 - Breaks down large long-lasting projects into sensible discrete chunks that compound to achieve a large goal
 

--- a/frameworks/engineering/web.md
+++ b/frameworks/engineering/web.md
@@ -161,12 +161,12 @@ Check out the original web engineering framework [here](https://eng-progression.
 ### Impact
 - Delivers large well-defined tasks and solves small scope not-well-defined problems
 
-- Contributes to writing RFCs (Co-authors with more experienced Engineer)
+- Contributes to writing proposals (Co-authors with more experienced Engineer)
 
 - Breaks down large problems into smaller iterative steps across multiple PRs
 
 ### Influence
-- Provides valuable input to RFCs from their team
+- Provides valuable input to proposals from their team
 
 - Proactively improves modules, services, systems and codebases they encounter, 'this doesn't make sense, I'm going to do something about it'
 
@@ -223,7 +223,7 @@ Check out the original web engineering framework [here](https://eng-progression.
 ### Impact
 - Solves ambiguous problems
 
-- Leads writing small/medium scope RFCs
+- Leads writing small/medium scope proposals
 
 - Thrown at fires and resolves / contributes heavily to resolving them
 
@@ -318,7 +318,7 @@ Check out the original web engineering framework [here](https://eng-progression.
 
 - Leading large scale technical infrastructure projects (level 5 would originate or complete, probably)
 
-- Leads writing large scope RFCs
+- Leads writing large scope proposals
 
 - Breaks down large long-lasting projects into sensible discrete chunks that compound to achieve a large goal
 


### PR DESCRIPTION
It was internally decided that we should use proposal rather
than RFC for clarity, specially among those not familiar with the
RFC acronym which is only commonly used within technical groups.