### PR TITLE
L4 influence: remove 'junior' from "Clears blockers for junior team members"

### DIFF
--- a/frameworks/engineering/backend.md
+++ b/frameworks/engineering/backend.md
@@ -149,7 +149,7 @@ topics:
         criteria:
           - "Positively influences engineers in the wider org"
           - "Maintains documentation on things they know the most, makes it easy for future engineers to interact with systems/code"
-          - "Clears blockers for junior team members, provides context/guidance, or knows how to escalate"
+          - "Clears blockers for team members, provides context/guidance, or knows how to escalate"
           - "Asks why. Does not take truths for granted unless they understand exactly where they are coming from (especially with regards to regulation, compliance, etc)"
           - "Drives changes to engineering practices with well-reasoned arguments and a 'strong opinion, weakly held' mentality"
           - "Shapes the direction of systems designs with less experienced engineers"


### PR DESCRIPTION
I think we should remove the 'junior' from this objective:

> Clears blockers for junior team members, provides context/guidance, or knows how to escalate

_All_ engineers routinely need unblocking. Every line of code written at Monzo is peer-reviewed through the PR process. Every proposal needs feedback.

I think it's importance to reward engineers for focussing on _squad_ productivity, and I think this change is a small step in that direction.