### PR TITLE
Introduce org-scaling team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,40 +2,40 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @monzo/@org-scaling
+*       @monzo/org-scaling
 
 # These owners will be the default owners for everything in the frameworks folder.
-frameworks/*        @monzo/@org-scaling
+frameworks/*        @monzo/org-scaling
 
 # These are owners for a specific engineering file extension
-*.js        @monzo/web-approvers @monzo/@org-scaling
-*.css       @monzo/web-approvers @monzo/@org-scaling
-*.json      @monzo/web-approvers @monzo/@org-scaling
+*.js        @monzo/web-approvers @monzo/org-scaling
+*.css       @monzo/web-approvers @monzo/org-scaling
+*.json      @monzo/web-approvers @monzo/org-scaling
 
 # These are owners for a specific framework area
-frameworks/operations/*         @bobbi-monzo @monzo/@org-scaling
-frameworks/design/*             @hugocornejo @monzo/@org-scaling
-frameworks/engineering/*        @andysmart @wpillar @robinjmurphy @monzo/@org-scaling
+frameworks/operations/*         @bobbi-monzo @monzo/org-scaling
+frameworks/design/*             @hugocornejo @monzo/org-scaling
+frameworks/engineering/*        @andysmart @wpillar @robinjmurphy @monzo/org-scaling
 
 # These are owners for a specific framework file
-frameworks/product.md               @ljkp @monzo/@org-scaling
-frameworks/people.md                @raramonzo @monzo/@org-scaling
-frameworks/generic.md               @emmanorthcott @monzo/@org-scaling
-frameworks/executive-support.md     @jonashuckestein @monzo/@org-scaling
+frameworks/product.md               @ljkp @monzo/org-scaling
+frameworks/people.md                @raramonzo @monzo/org-scaling
+frameworks/generic.md               @emmanorthcott @monzo/org-scaling
+frameworks/executive-support.md     @jonashuckestein @monzo/org-scaling
 
 # These are owners for a specific engineering file or folder
-src/*                   @monzo/web-approvers @monzo/@org-scaling
-stubs/*                 @monzo/web-approvers @monzo/@org-scaling
-.eslintignore           @monzo/web-approvers @monzo/@org-scaling
-.eslintrc               @monzo/web-approvers @monzo/@org-scaling
-.flowconfig             @monzo/web-approvers @monzo/@org-scaling
-.gitignore              @monzo/web-approvers @monzo/@org-scaling
-.prettierrc             @monzo/web-approvers @monzo/@org-scaling
-CODEOWNERS              @monzo/@org-scaling
-README.md               @monzo/web-approvers @monzo/@org-scaling
-gatsby-config.js        @monzo/web-approvers @monzo/@org-scaling
-gatsby-browser.js       @monzo/web-approvers @monzo/@org-scaling
-gatsby-node.js          @monzo/web-approvers @monzo/@org-scaling
-netlify.toml            @monzo/web-approvers @monzo/@org-scaling
-package.json            @monzo/web-approvers @monzo/@org-scaling
-yarn.lock               @monzo/web-approvers @monzo/@org-scaling
+src/*                   @monzo/web-approvers @monzo/org-scaling
+stubs/*                 @monzo/web-approvers @monzo/org-scaling
+.eslintignore           @monzo/web-approvers @monzo/org-scaling
+.eslintrc               @monzo/web-approvers @monzo/org-scaling
+.flowconfig             @monzo/web-approvers @monzo/org-scaling
+.gitignore              @monzo/web-approvers @monzo/org-scaling
+.prettierrc             @monzo/web-approvers @monzo/org-scaling
+CODEOWNERS              @monzo/org-scaling
+README.md               @monzo/web-approvers @monzo/org-scaling
+gatsby-config.js        @monzo/web-approvers @monzo/org-scaling
+gatsby-browser.js       @monzo/web-approvers @monzo/org-scaling
+gatsby-node.js          @monzo/web-approvers @monzo/org-scaling
+netlify.toml            @monzo/web-approvers @monzo/org-scaling
+package.json            @monzo/web-approvers @monzo/org-scaling
+yarn.lock               @monzo/web-approvers @monzo/org-scaling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,40 +2,40 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @lucasjohnston
+*       @org-scaling
 
 # These owners will be the default owners for everything in the frameworks folder.
-frameworks/*        @emmanorthcott
+frameworks/*        @org-scaling
 
 # These are owners for a specific engineering file extension
-*.js        @monzo/web-approvers
-*.css       @monzo/web-approvers
-*.json      @monzo/web-approvers
+*.js        @monzo/web-approvers @org-scaling
+*.css       @monzo/web-approvers @org-scaling
+*.json      @monzo/web-approvers @org-scaling
 
 # These are owners for a specific framework area
-frameworks/operations/*         @bobbi-monzo
-frameworks/design/*             @hugocornejo
-frameworks/engineering/*        @andysmart @wpillar @robinjmurphy
+frameworks/operations/*         @bobbi-monzo @org-scaling
+frameworks/design/*             @hugocornejo @org-scaling
+frameworks/engineering/*        @andysmart @wpillar @robinjmurphy @org-scaling
 
 # These are owners for a specific framework file
-frameworks/product.md               @ljkp
-frameworks/people.md                @raramonzo
-frameworks/generic.md               @emmanorthcott
-frameworks/executive-support.md     @jonashuckestein
+frameworks/product.md               @ljkp @org-scaling
+frameworks/people.md                @raramonzo @org-scaling
+frameworks/generic.md               @emmanorthcott @org-scaling
+frameworks/executive-support.md     @jonashuckestein @org-scaling
 
 # These are owners for a specific engineering file or folder
-src/*                   @monzo/web-approvers
-stubs/*                 @monzo/web-approvers
-.eslintignore           @monzo/web-approvers
-.eslintrc               @monzo/web-approvers
-.flowconfig             @monzo/web-approvers
-.gitignore              @monzo/web-approvers
-.prettierrc             @monzo/web-approvers
-CODEOWNERS              @lucas @emmanorthcott
-README.md               @monzo/web-approvers
-gatsby-config.js        @monzo/web-approvers
-gatsby-browser.js       @monzo/web-approvers
-gatsby-node.js          @monzo/web-approvers
-netlify.toml            @monzo/web-approvers
-package.json            @monzo/web-approvers
-yarn.lock               @monzo/web-approvers
+src/*                   @monzo/web-approvers @org-scaling
+stubs/*                 @monzo/web-approvers @org-scaling
+.eslintignore           @monzo/web-approvers @org-scaling
+.eslintrc               @monzo/web-approvers @org-scaling
+.flowconfig             @monzo/web-approvers @org-scaling
+.gitignore              @monzo/web-approvers @org-scaling
+.prettierrc             @monzo/web-approvers @org-scaling
+CODEOWNERS              @org-scaling
+README.md               @monzo/web-approvers @org-scaling
+gatsby-config.js        @monzo/web-approvers @org-scaling
+gatsby-browser.js       @monzo/web-approvers @org-scaling
+gatsby-node.js          @monzo/web-approvers @org-scaling
+netlify.toml            @monzo/web-approvers @org-scaling
+package.json            @monzo/web-approvers @org-scaling
+yarn.lock               @monzo/web-approvers @org-scaling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,40 +2,40 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @org-scaling
+*       @monzo/@org-scaling
 
 # These owners will be the default owners for everything in the frameworks folder.
-frameworks/*        @org-scaling
+frameworks/*        @monzo/@org-scaling
 
 # These are owners for a specific engineering file extension
-*.js        @monzo/web-approvers @org-scaling
-*.css       @monzo/web-approvers @org-scaling
-*.json      @monzo/web-approvers @org-scaling
+*.js        @monzo/web-approvers @monzo/@org-scaling
+*.css       @monzo/web-approvers @monzo/@org-scaling
+*.json      @monzo/web-approvers @monzo/@org-scaling
 
 # These are owners for a specific framework area
-frameworks/operations/*         @bobbi-monzo @org-scaling
-frameworks/design/*             @hugocornejo @org-scaling
-frameworks/engineering/*        @andysmart @wpillar @robinjmurphy @org-scaling
+frameworks/operations/*         @bobbi-monzo @monzo/@org-scaling
+frameworks/design/*             @hugocornejo @monzo/@org-scaling
+frameworks/engineering/*        @andysmart @wpillar @robinjmurphy @monzo/@org-scaling
 
 # These are owners for a specific framework file
-frameworks/product.md               @ljkp @org-scaling
-frameworks/people.md                @raramonzo @org-scaling
-frameworks/generic.md               @emmanorthcott @org-scaling
-frameworks/executive-support.md     @jonashuckestein @org-scaling
+frameworks/product.md               @ljkp @monzo/@org-scaling
+frameworks/people.md                @raramonzo @monzo/@org-scaling
+frameworks/generic.md               @emmanorthcott @monzo/@org-scaling
+frameworks/executive-support.md     @jonashuckestein @monzo/@org-scaling
 
 # These are owners for a specific engineering file or folder
-src/*                   @monzo/web-approvers @org-scaling
-stubs/*                 @monzo/web-approvers @org-scaling
-.eslintignore           @monzo/web-approvers @org-scaling
-.eslintrc               @monzo/web-approvers @org-scaling
-.flowconfig             @monzo/web-approvers @org-scaling
-.gitignore              @monzo/web-approvers @org-scaling
-.prettierrc             @monzo/web-approvers @org-scaling
-CODEOWNERS              @org-scaling
-README.md               @monzo/web-approvers @org-scaling
-gatsby-config.js        @monzo/web-approvers @org-scaling
-gatsby-browser.js       @monzo/web-approvers @org-scaling
-gatsby-node.js          @monzo/web-approvers @org-scaling
-netlify.toml            @monzo/web-approvers @org-scaling
-package.json            @monzo/web-approvers @org-scaling
-yarn.lock               @monzo/web-approvers @org-scaling
+src/*                   @monzo/web-approvers @monzo/@org-scaling
+stubs/*                 @monzo/web-approvers @monzo/@org-scaling
+.eslintignore           @monzo/web-approvers @monzo/@org-scaling
+.eslintrc               @monzo/web-approvers @monzo/@org-scaling
+.flowconfig             @monzo/web-approvers @monzo/@org-scaling
+.gitignore              @monzo/web-approvers @monzo/@org-scaling
+.prettierrc             @monzo/web-approvers @monzo/@org-scaling
+CODEOWNERS              @monzo/@org-scaling
+README.md               @monzo/web-approvers @monzo/@org-scaling
+gatsby-config.js        @monzo/web-approvers @monzo/@org-scaling
+gatsby-browser.js       @monzo/web-approvers @monzo/@org-scaling
+gatsby-node.js          @monzo/web-approvers @monzo/@org-scaling
+netlify.toml            @monzo/web-approvers @monzo/@org-scaling
+package.json            @monzo/web-approvers @monzo/@org-scaling
+yarn.lock               @monzo/web-approvers @monzo/@org-scaling


### PR DESCRIPTION
This will allows us to view Progression Framework changes in the #org-scaling-eng channel, and means Org Scaling team members look over changes to the site to ensure they fit in line with the direction of the framework site. For example, that a framework owner does not introduce a framework that is out of line with CalCo.