### PR TITLE
Rename the org-scaling team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,40 +2,40 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @monzo/org-scaling
+*       @monzo/org-scaling-team
 
 # These owners will be the default owners for everything in the frameworks folder.
-frameworks/*        @monzo/org-scaling
+frameworks/*        @monzo/org-scaling-team
 
 # These are owners for a specific engineering file extension
-*.js        @monzo/web-approvers @monzo/org-scaling
-*.css       @monzo/web-approvers @monzo/org-scaling
-*.json      @monzo/web-approvers @monzo/org-scaling
+*.js        @monzo/web-approvers @monzo/org-scaling-team
+*.css       @monzo/web-approvers @monzo/org-scaling-team
+*.json      @monzo/web-approvers @monzo/org-scaling-team
 
 # These are owners for a specific framework area
-frameworks/operations/*         @bobbi-monzo @monzo/org-scaling
-frameworks/design/*             @hugocornejo @monzo/org-scaling
-frameworks/engineering/*        @andysmart @wpillar @robinjmurphy @monzo/org-scaling
+frameworks/operations/*         @bobbi-monzo @monzo/org-scaling-team
+frameworks/design/*             @hugocornejo @monzo/org-scaling-team
+frameworks/engineering/*        @andysmart @wpillar @robinjmurphy @monzo/org-scaling-team
 
 # These are owners for a specific framework file
-frameworks/product.md               @ljkp @monzo/org-scaling
-frameworks/people.md                @raramonzo @monzo/org-scaling
-frameworks/generic.md               @emmanorthcott @monzo/org-scaling
-frameworks/executive-support.md     @jonashuckestein @monzo/org-scaling
+frameworks/product.md               @ljkp @monzo/org-scaling-team
+frameworks/people.md                @raramonzo @monzo/org-scaling-team
+frameworks/generic.md               @emmanorthcott @monzo/org-scaling-team
+frameworks/executive-support.md     @jonashuckestein @monzo/org-scaling-team
 
 # These are owners for a specific engineering file or folder
-src/*                   @monzo/web-approvers @monzo/org-scaling
-stubs/*                 @monzo/web-approvers @monzo/org-scaling
-.eslintignore           @monzo/web-approvers @monzo/org-scaling
-.eslintrc               @monzo/web-approvers @monzo/org-scaling
-.flowconfig             @monzo/web-approvers @monzo/org-scaling
-.gitignore              @monzo/web-approvers @monzo/org-scaling
-.prettierrc             @monzo/web-approvers @monzo/org-scaling
-CODEOWNERS              @monzo/org-scaling
-README.md               @monzo/web-approvers @monzo/org-scaling
-gatsby-config.js        @monzo/web-approvers @monzo/org-scaling
-gatsby-browser.js       @monzo/web-approvers @monzo/org-scaling
-gatsby-node.js          @monzo/web-approvers @monzo/org-scaling
-netlify.toml            @monzo/web-approvers @monzo/org-scaling
-package.json            @monzo/web-approvers @monzo/org-scaling
-yarn.lock               @monzo/web-approvers @monzo/org-scaling
+src/*                   @monzo/web-approvers @monzo/org-scaling-team
+stubs/*                 @monzo/web-approvers @monzo/org-scaling-team
+.eslintignore           @monzo/web-approvers @monzo/org-scaling-team
+.eslintrc               @monzo/web-approvers @monzo/org-scaling-team
+.flowconfig             @monzo/web-approvers @monzo/org-scaling-team
+.gitignore              @monzo/web-approvers @monzo/org-scaling-team
+.prettierrc             @monzo/web-approvers @monzo/org-scaling-team
+CODEOWNERS              @monzo/org-scaling-team
+README.md               @monzo/web-approvers @monzo/org-scaling-team
+gatsby-config.js        @monzo/web-approvers @monzo/org-scaling-team
+gatsby-browser.js       @monzo/web-approvers @monzo/org-scaling-team
+gatsby-node.js          @monzo/web-approvers @monzo/org-scaling-team
+netlify.toml            @monzo/web-approvers @monzo/org-scaling-team
+package.json            @monzo/web-approvers @monzo/org-scaling-team
+yarn.lock               @monzo/web-approvers @monzo/org-scaling-team


### PR DESCRIPTION
This PR is to rename the CODEOWNERS team for org-scaling to keep in line with the spec we use across all teams.

See this for more: https://paper.dropbox.com/doc/RFC-GitHub-Permissions-NBTizjT6x0ThMLdkFCHmc