### PR TITLE
Fix GitHub icon rendering on homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,8 +3,8 @@ import * as React from 'react'
 import { graphql } from 'gatsby'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
-import { config } from "@fortawesome/fontawesome-svg-core"
-import "@fortawesome/fontawesome-svg-core/styles.css"
+import { config } from '@fortawesome/fontawesome-svg-core'
+import '@fortawesome/fontawesome-svg-core/styles.css'
 import illustration from '../images/intro_illustration.svg'
 import Layout from '../components/layout'
 import {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,6 +3,8 @@ import * as React from 'react'
 import { graphql } from 'gatsby'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
+import { config } from "@fortawesome/fontawesome-svg-core"
+import "@fortawesome/fontawesome-svg-core/styles.css"
 import illustration from '../images/intro_illustration.svg'
 import Layout from '../components/layout'
 import {
@@ -16,6 +18,8 @@ import {
   DescriptionContainer,
 } from '../components/styles'
 import '../css/main.min.css'
+
+config.autoAddCss = false
 
 type Props = {
   data: Object,


### PR DESCRIPTION
There was an issue on the homepage causing the GitHub icon to render at a significantly larger size than expected, before shrinking to the intended dimensions. This pull request should prevent that from happening, closing #28.