### PR TITLE
Fix Loading issues / FOUC 🐛

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -72,7 +72,7 @@ const SidebarRenderer = ({
   ) : null
 
 class Layout extends React.Component<Props, State> {
-  state = { isSidebarVisible: false }
+  state = { isSidebarVisible: window.innerWidth > BREAKPOINT_MOBILE }
 
   componentDidMount() {
     this.updateSidebarOnResize()

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -85,7 +85,7 @@ export default class Index extends React.Component<Props, State> {
             <DescriptionText>
               To get involved, go to{' '}
               <a href="https://github.com/monzo/progression-framework">
-                <FontAwesomeIcon icon={faGithub} />{' '}
+                <FontAwesomeIcon size="1x" icon={faGithub} />{' '}
                 @monzo/progression-framework.
               </a>
             </DescriptionText>


### PR DESCRIPTION
The FOUC (Flash of Unstyled Content) bug comes down to one main thing, which is that JavaScript is only loaded on this static site ~1-4s in. Static content from the build is loaded first, resulting in the jankiness. I'm going to try to spend some time looking at how to reduce this (and removing unused deps) sometime next week.

This manifests itself in two primary ways:
First, the GitHub logo from `font-awesome`. The cause of this was font-awesome's autoCSS, as this requires JavaScript to work. As it's an svg it defaults to being _big_ and only scales down to `1x` size after JavaScript is loaded. In this case simplicity is bliss - we can just specify the `1x` fixed size prop and we're done.
Second is the sidebar paint. The reason why this happens is that the sidebar is hidden by default, based on a component state called `isSidebarVisible`. This is false by default, meaning that the sidebar is hidden by default during page load. However, when `componentDidMount` is called, we attach window resize listeners who either make the sidebar visible / not visible depending on the size of your window. However, `componentDidMount` and these resize listeners are only added once the javascript has loaded. This one is also a super simple fix - just using the responsive code we use in the resize method (`window.innerWidth > BREAKPOINT_MOBILE`) and making that the default state, so that there's no jumpiness. 

Looking in the performance editor, the load is still incremental (ie. css + images are rendered first, followed by title text, followed by body text) but this is far better than before and, imo, acceptable.
Unfortunately it's taken a while for me to get round to look at this - and of course it's two _tiny_ changes that fix it 😅

This will close issue #17 and #31 - thank you @tmhn for raising the issue and @brks for suggesting a fix! It's massively appreciated ❤️