### PR TITLE
Fix sidebar rendering on page load

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -48,28 +48,27 @@ const SidebarRenderer = ({
   sidebarClickHandler,
   isSidebarVisible,
   data,
-}: Object) =>
-  isSidebarVisible ? (
-    <Location>
-      {({ location }) => (
-        <Sidebar>
-          <SidebarReset>
-            <SidebarScroll>
-              <ScrollbarHeader>
-                <SidebarIcon src={favicon} alt="Monzo" />
-                <FlexboxPush>
-                  <CloseIcon onClick={sidebarClickHandler} src={closeIcon} />
-                </FlexboxPush>
-              </ScrollbarHeader>
-              <SidebarList main>
-                <SidebarBuilder data={data} location={location} />
-              </SidebarList>
-            </SidebarScroll>
-          </SidebarReset>
-        </Sidebar>
-      )}
-    </Location>
-  ) : null
+}: Object) => (
+  <Location>
+    {({ location }) => (
+      <Sidebar className={isSidebarVisible ? 'visible' : null}>
+        <SidebarReset>
+          <SidebarScroll>
+            <ScrollbarHeader>
+              <SidebarIcon src={favicon} alt="Monzo" />
+              <FlexboxPush>
+                <CloseIcon onClick={sidebarClickHandler} src={closeIcon} />
+              </FlexboxPush>
+            </ScrollbarHeader>
+            <SidebarList main>
+              <SidebarBuilder data={data} location={location} />
+            </SidebarList>
+          </SidebarScroll>
+        </SidebarReset>
+      </Sidebar>
+    )}
+  </Location>
+)
 
 class Layout extends React.Component<Props, State> {
   state = { isSidebarVisible: false }

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -327,6 +327,7 @@ export const ToolbarIcon = styled.img`
 export const MenuIcon = styled.img`
   width: auto;
   height: auto;
+  cursor: pointer;
 
   @media all and (max-width: ${BREAKPOINT_MOBILE}px) {
     display: inherit;
@@ -356,12 +357,16 @@ export const Sidebar = styled.div`
   }
 
   @media all and (max-width: ${BREAKPOINT_MOBILE}px) {
-    width: 100% !important;
+    display: none;
+    width: 100%;
     height: 100%;
     align-items: center;
     justify-content: center;
     min-width: 250px;
     transform: none;
+    &.visible {
+      display: flex;
+    }
   }
 `
 


### PR DESCRIPTION
Along with the issue concerning the sizing of the GitHub icon on the homepage raised in #28, there was an issue with the rendering of the sidebar that is explained in detail in #32. This pull request should prevent that issue from occurring and when paired with the fix in #31, prevent any kind of rendering issues on page load. 