### PR TITLE
[OSC-62 OSC-63 OSC-67 OSC-70] Housekeeping 🧹

### DIFF
--- a/frameworks/engineering/backend.md
+++ b/frameworks/engineering/backend.md
@@ -5,7 +5,7 @@ sidebarTitle: "🛠️ Backend"
 sidebarGroup: "engineering"
 yaml: true
 levels: 6
-homepage: true
+homepage:
 topics:
   - name: "communication"
     title:

--- a/frameworks/engineering/backend.md
+++ b/frameworks/engineering/backend.md
@@ -5,7 +5,7 @@ sidebarTitle: "🛠️ Backend"
 sidebarGroup: "engineering"
 yaml: true
 levels: 6
-homepage:
+homepage: false
 topics:
   - name: "communication"
     title:

--- a/frameworks/engineering/data.md
+++ b/frameworks/engineering/data.md
@@ -255,7 +255,7 @@ topics:
         criteria:
           - "Delivers projects that require cross functional collaboration"
           - "Delegates to make better use of their time"
-  - name: "mastery"
+  - name: "mastery-science"
     title: "🧪 Mastery - Data Science"
     description: "Your knowledge of Data Science at Monzo"
     content:
@@ -299,7 +299,7 @@ topics:
           - "Deep domain knowledge, can go lower than almost anyone else"
           - "Makes targeted improvements in stability, performance and scalability across our platform"
           - "Measurable impact on company level goals"
-  - name: "mastery"
+  - name: "mastery-analytics"
     title: "📈 Mastery - Data Analytics"
     description: "Your knowledge of Data Analytics at Monzo"
     content:

--- a/frameworks/people.md
+++ b/frameworks/people.md
@@ -2,7 +2,7 @@
 path: "/frameworks/people"
 title: "🙂 People"
 sidebarTitle: "🙂 People"
-sidebarGroup: null
+sidebarGroup:
 yaml: true
 levels: 6
 homepage: false

--- a/src/components/renderers/levelledRenderer.js
+++ b/src/components/renderers/levelledRenderer.js
@@ -85,15 +85,27 @@ class ExampleCriteriaComponent extends React.Component<
 export default class LevelledRenderer extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    const genericDataTitles = props.genericData.topics.map(obj => obj.name)
-    const pageDataTitles = props.pageData.topics.map(obj => obj.name)
+    const genericDataTitles = props.genericData.topics.map(obj => obj.title)
+    const pageDataTitles = props.pageData.topics.map(obj => obj.title)
+    const genericDataNames = props.genericData.topics.map(obj => obj.name)
+    const pageDataNames = props.pageData.topics.map(obj => obj.name)
+
+    // isGeneric checks to see if the variable names and the "Title" is present on both the generic
+    // and page date we receive. This should only flag the generic framework, unless someone redeclares the
+    // framework titles and variable names in a new framework (which should not get past review)
+    const matchingNames = match(genericDataNames, pageDataNames)
+    const matchingTitles = match(genericDataTitles, pageDataTitles)
+    const isGeneric = matchingNames && matchingTitles
+
+    // inheritsGeneric checks to see if some of the page data and generic framework variable
+    // names are shared which is how our inheritance works), but the titles do not exactly match
+    const containingNames = contains(genericDataNames, pageDataNames)
+    const inheritsGeneric = containingNames && !matchingTitles
 
     this.state = {
       level: null,
-      isGeneric: match(genericDataTitles, pageDataTitles),
-      inheritsGeneric:
-        contains(genericDataTitles, pageDataTitles) &&
-        !match(genericDataTitles, pageDataTitles),
+      isGeneric,
+      inheritsGeneric,
     }
   }
 
@@ -120,14 +132,13 @@ export default class LevelledRenderer extends React.Component<Props, State> {
   renderEmptyState() {
     const { pageData, html } = this.props
 
-    if (pageData.homepage === true) {
+    if (pageData.homepage === true && html !== '') {
       return (
         <Card>
           <MarkdownContent dangerouslySetInnerHTML={{ __html: html }} />
         </Card>
       )
     } else {
-      console.log(pageData.homepage)
       return (
         <CenteredElement>
           <Card>


### PR DESCRIPTION
This PR:

- [x] Removes stray console.log() and removes the homepage from Backend eng (OSC-4 fixes)
- [x] Fixes the framework rendering bugs by making the isGeneric check more explicit
- [x] Adds an empty check to the homepage render statement
- [x] Fixes a duplicate key error in the data eng framework