### PR TITLE
Add product quality behaviours to mobile mastery

### DIFF
--- a/frameworks/engineering/mobile.md
+++ b/frameworks/engineering/mobile.md
@@ -172,7 +172,7 @@ topics:
           - "Builds simple screens or flows"
           - "Asks questions and actions feedback from PRs and other engineers"
           - "Fixes simple bugs or issues"
-          - "Builds simple screens in collobration with a designer"
+          - "Produces well-polished interfaces in collaboration with a designer"
       - level: 2
         criteria:
           - "Uses appropriate algorithms and data structures to solve problems"
@@ -187,6 +187,7 @@ topics:
           - "Appropriately uses common functional reactive programming concepts"
           - "Designs database models"
           - "Appropriately handles errors or failure conditions in their code"
+          - "Produces well-polished multi screen interfaces in collaboration with a designer, handling empty, error, and loading states gracefully"
         exampleCriteria:
           - criteria: "Integrates with new APIs"
             examples:
@@ -196,25 +197,25 @@ topics:
             examples:
               - "Can reason whether to use asynchronous or synchronous operations"
               - "Understands impact on app performance to use either"
-          - "Builds multi screen flows in collobration with a designer, handling empty, error, and loading states gracefully"
       - level: 3
         criteria:
           - "Uses tools to diagnose and improve performance issues"
           - "Builds non-trivial, coordinated app flows with multiple services and data sources"
           - "Builds complex UI layouts in code or via IDE"
           - "Contributes to group standards, impactful in improving our processes"
+          - "Proactively improves empty, error and loading states in screens & flows they encounter, works closely with designers to identify problem areas and suggest improvements"
         exampleCriteria:
           - criteria: "Adds migrations to handle changes between old and new app versions"
             examples:
               - "Owning migration from major language versions"
               - "Handling complex changes to third party dependencies"
               - "Writing migrations from one data schema to another"
-          - "Proactively improves empty, error and loading states in screens & flows they encounter, works closely with designers to identify problem areas and suggest improvements"
       - level: 4
         criteria:
           - "Writes code that serves as a definitive example for new engineers"
           - "Identifies and fixes security vulnerabilities"
           - "Sought out for reviewing complex changes or commenting on larger scale proposals"
+          - "Builds non trivial complex flows that serve as an example of a high quality product"
         exampleCriteria:
           - criteria: "Owns and coordinates large scale architectural changes to the entire codebase"
             examples:
@@ -230,11 +231,11 @@ topics:
             examples:
               - "Coordinates with backend developers around API specifications and requirements."
               - "Able to digest into discrete tasks and work with peers to solve problem in an efficient manner to avoid blockers."
-          - "Builds non trivial complex flows that serve as an example of a high quality product"
       - level: 5
         criteria:
           - "Anticipates large or significant platform changes, work with team to define possible solutions. Starts or finishes these projects."
           - "Takes high level requirements and turns them into discrete technical concerns"
+          - "Instills and maintains a culture of high quality in their discipline"
         exampleCriteria:
           - criteria: "Coordinates group efforts across horizontal"
             examples:
@@ -246,7 +247,6 @@ topics:
             examples:
               - "Able to handle situations where domain knowledge does not exist in the company and can lead the effort to resolve them."
               - "For example, resolving issues with our compiler and mapping out code paths for 'hard to reproduce' issues"
-           - "Instills and maintains a culture of high quality in their discipline"
 ---
 ### About our engineering progression frameworks
 The engineering progression framework is a tool that helps engineers and managers:

--- a/frameworks/engineering/mobile.md
+++ b/frameworks/engineering/mobile.md
@@ -172,6 +172,7 @@ topics:
           - "Builds simple screens or flows"
           - "Asks questions and actions feedback from PRs and other engineers"
           - "Fixes simple bugs or issues"
+          - "Builds simple screens in collobration with a designer"
       - level: 2
         criteria:
           - "Uses appropriate algorithms and data structures to solve problems"
@@ -195,6 +196,7 @@ topics:
             examples:
               - "Can reason whether to use asynchronous or synchronous operations"
               - "Understands impact on app performance to use either"
+          - "Builds multi screen flows in collobration with a designer, handling empty, error, and loading states gracefully"
       - level: 3
         criteria:
           - "Uses tools to diagnose and improve performance issues"
@@ -207,6 +209,7 @@ topics:
               - "Owning migration from major language versions"
               - "Handling complex changes to third party dependencies"
               - "Writing migrations from one data schema to another"
+          - "Proactively improves empty, error and loading states in screens & flows they encounter, works closely with designers to identify problem areas and suggest improvements"
       - level: 4
         criteria:
           - "Writes code that serves as a definitive example for new engineers"
@@ -227,6 +230,7 @@ topics:
             examples:
               - "Coordinates with backend developers around API specifications and requirements."
               - "Able to digest into discrete tasks and work with peers to solve problem in an efficient manner to avoid blockers."
+          - "Builds non trivial complex flows that serve as an example of a high quality product"
       - level: 5
         criteria:
           - "Anticipates large or significant platform changes, work with team to define possible solutions. Starts or finishes these projects."
@@ -242,6 +246,7 @@ topics:
             examples:
               - "Able to handle situations where domain knowledge does not exist in the company and can lead the effort to resolve them."
               - "For example, resolving issues with our compiler and mapping out code paths for 'hard to reproduce' issues"
+           - "Instills and maintains a culture of high quality in their discipline"
 ---
 ### About our engineering progression frameworks
 The engineering progression framework is a tool that helps engineers and managers:

--- a/frameworks/engineering/mobile.md
+++ b/frameworks/engineering/mobile.md
@@ -172,7 +172,6 @@ topics:
           - "Builds simple screens or flows"
           - "Asks questions and actions feedback from PRs and other engineers"
           - "Fixes simple bugs or issues"
-          - "Handles empty, error & loading states in simple screens or flows"
       - level: 2
         criteria:
           - "Uses appropriate algorithms and data structures to solve problems"
@@ -187,7 +186,7 @@ topics:
           - "Appropriately uses common functional reactive programming concepts"
           - "Designs database models"
           - "Appropriately handles errors or failure conditions in their code"
-          - "Handles empty, error, and loading states gracefully in multi screen flows"
+          - "Works with designers to handle empty, error, and loading states in multi screen flows"
         exampleCriteria:
           - criteria: "Integrates with new APIs"
             examples:
@@ -215,7 +214,7 @@ topics:
           - "Writes code that serves as a definitive example for new engineers"
           - "Identifies and fixes security vulnerabilities"
           - "Sought out for reviewing complex changes or commenting on larger scale proposals"
-          - "Builds non trivial complex flows that serve as an example of high quality interaction design"
+          - "Builds flows that serve as an example of high quality interaction design"
         exampleCriteria:
           - criteria: "Owns and coordinates large scale architectural changes to the entire codebase"
             examples:
@@ -235,7 +234,7 @@ topics:
         criteria:
           - "Anticipates large or significant platform changes, work with team to define possible solutions. Starts or finishes these projects."
           - "Takes high level requirements and turns them into discrete technical concerns"
-          - "Instills and maintains a culture of high quality in their discipline"
+          - "Instills and maintains a culture of high quality interaction design in their discipline"
         exampleCriteria:
           - criteria: "Coordinates group efforts across horizontal"
             examples:

--- a/frameworks/engineering/mobile.md
+++ b/frameworks/engineering/mobile.md
@@ -172,7 +172,7 @@ topics:
           - "Builds simple screens or flows"
           - "Asks questions and actions feedback from PRs and other engineers"
           - "Fixes simple bugs or issues"
-          - "Produces well-polished interfaces in collaboration with a designer"
+          - "Handles empty, error & loading states in simple screens or flows"
       - level: 2
         criteria:
           - "Uses appropriate algorithms and data structures to solve problems"
@@ -187,7 +187,7 @@ topics:
           - "Appropriately uses common functional reactive programming concepts"
           - "Designs database models"
           - "Appropriately handles errors or failure conditions in their code"
-          - "Produces well-polished multi screen interfaces in collaboration with a designer, handling empty, error, and loading states gracefully"
+          - "Handles empty, error, and loading states gracefully in multi screen flows"
         exampleCriteria:
           - criteria: "Integrates with new APIs"
             examples:
@@ -215,7 +215,7 @@ topics:
           - "Writes code that serves as a definitive example for new engineers"
           - "Identifies and fixes security vulnerabilities"
           - "Sought out for reviewing complex changes or commenting on larger scale proposals"
-          - "Builds non trivial complex flows that serve as an example of a high quality product"
+          - "Builds non trivial complex flows that serve as an example of high quality interaction design"
         exampleCriteria:
           - criteria: "Owns and coordinates large scale architectural changes to the entire codebase"
             examples:


### PR DESCRIPTION
Mobile mastery is currently missing behaviours related to product quality, this pull request proposes some new behaviours that reflect building high quality products.

These changes could also translate well to the web framework or any engineers building customer facing products.

**For example:**

* Handling empty states.
* Working closely in collaboration with designers.
* Handling loading states.
* Gracefully handling errors.
* Proactively suggesting improvements.