### PR TITLE
Add backend engineer criteria for considering security implications

### DIFF
--- a/frameworks/engineering/backend.md
+++ b/frameworks/engineering/backend.md
@@ -209,6 +209,8 @@ topics:
           - criteria: "Proactively considers security implications of their work"    
             examples:
               - "Appropriately ties down internal access to resources they're working with (e.g. RPC blacklisting, BigQuery permissions)"
+              - "Evaluates security risks when contributing to proposals"
+              - "Highlights potential security issues when raising and reviewing pull requests - e.g. adding rate limiting in an API, or leaving a code comment to explain why we choose not to"
               - "\"There's a risk here of X, Y but given Z, I think this is OK\""
               - "Loops in Security when their squad is unsure about something by posting in #security-requests"
       - level: 4

--- a/frameworks/engineering/backend.md
+++ b/frameworks/engineering/backend.md
@@ -210,7 +210,7 @@ topics:
             examples:
               - "Appropriately ties down internal access to resources they're working with (e.g. RPC blacklisting, BigQuery permissions)"
               - "\"There's a risk here of X, Y but given Z, I think this is OK\""
-              - "Loops in Security when their squad is unsure about something"
+              - "Loops in Security when their squad is unsure about something by posting in #security-requests"
       - level: 4
         criteria:
           - "Writes code that serves as a definitive example for new engineers"

--- a/frameworks/engineering/backend.md
+++ b/frameworks/engineering/backend.md
@@ -206,6 +206,11 @@ topics:
           - criteria: "Implements complex RPC handlers"
             examples:
               - "Implements complex business logic, orchestrates multi-stage processes, deals with idempotency or distributed data sources"
+          - criteria: "Proactively considers security implications of their work"    
+            examples:
+              - "Appropriately ties down internal access to resources they're working with (e.g. RPC blacklisting, BigQuery permissions)"
+              - "\"There's a risk here of X, Y but given Z, I think this is OK\""
+              - "Loops in Security when their squad is unsure about something"
       - level: 4
         criteria:
           - "Writes code that serves as a definitive example for new engineers"


### PR DESCRIPTION
## Rationale
The rationale behind this change is to encourage backend engineers
outside of the security team to adopt a security mindset.

This is a step towards better embedding engineering security principles in squads.


I'd be particular keen to hear if there's anyway we could improve the examples or rephrase the criteria itself.

## Building/Deploying
I haven't yet run `gatsby build` as it'll add a bunch of extra changes to this PR - once we've figured out where we want to take this, I'll do a build as per usual.

## Screenshot
![image](https://user-images.githubusercontent.com/9294710/60352941-d5212300-99c0-11e9-820f-e892fe0c76e6.png)


